### PR TITLE
Multi-AZ Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ terraform-docs md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
 | create_resources | Whether to create the Aurora cluster and related resources | string | `true` | no |
 | engine_version | Redis engine verions | string | `4.0.10` | no |
 | maintenance_window | When to perform maintenance | string | `sun:02:30-sun:03:30` | no |
+| multi_az_enabled | Specifies whether to enable Multi-AZ Support for the replication group. If true, `number_cache_clusters` must be greater than 1. | bool | `true` | no |
 | name | Name given resources | string | - | yes |
 | node_type | Instance type to use | string | `cache.t2.micro` | no |
 | notification_topic_arn | Notification topic ARN for the cluster | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ terraform-docs md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
 | create_resources | Whether to create the Aurora cluster and related resources | string | `true` | no |
 | engine_version | Redis engine verions | string | `4.0.10` | no |
 | maintenance_window | When to perform maintenance | string | `sun:02:30-sun:03:30` | no |
-| multi_az_enabled | Specifies whether to enable Multi-AZ Support for the replication group. If true, `number_cache_clusters` must be greater than 1. | bool | `true` | no |
+| multi_az_enabled | Specifies whether to enable Multi-AZ Support for the replication group. Applied only when `number_cache_clusters` is greater than 1. | bool | `true` | no |
 | name | Name given resources | string | - | yes |
 | node_type | Instance type to use | string | `cache.t2.micro` | no |
 | notification_topic_arn | Notification topic ARN for the cluster | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,11 @@
+locals {
+  automatic_failover_enabled  = var.number_cache_clusters > 1 ? true : false
+}
+
 resource "aws_elasticache_replication_group" "redis" {
   replication_group_id          = var.name
   replication_group_description = var.name
-  automatic_failover_enabled    = var.number_cache_clusters > 1 ? true : false
+  automatic_failover_enabled    = local.automatic_failover_enabled
   number_cache_clusters         = var.number_cache_clusters
   node_type                     = var.node_type
   engine_version                = var.engine_version
@@ -13,6 +17,7 @@ resource "aws_elasticache_replication_group" "redis" {
   port                          = var.port
   apply_immediately             = var.apply_immediately
   tags                          = var.tags
+  multi_az_enabled              = local.automatic_failover_enabled ? var.multi_az_enabled : false
 }
 
 resource "aws_elasticache_subnet_group" "redis" {

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,11 @@ variable "tags" {
   description = "A map of tags to add to all resources."
 }
 
+variable "multi_az_enabled" {
+  description = "Specifies whether to enable Multi-AZ Support for the replication group. If true, number_cache_clusters must be greater than 1."
+  default     = true
+}
+
 variable "parameter_group_family" {
   default = "redis4.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "tags" {
 }
 
 variable "multi_az_enabled" {
-  description = "Specifies whether to enable Multi-AZ Support for the replication group. If true, number_cache_clusters must be greater than 1."
+  description = "Specifies whether to enable Multi-AZ Support for the replication group. Applied only when `number_cache_clusters` is greater than 1."
   default     = true
 }
 


### PR DESCRIPTION
Since the version [3.26.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.26.0), AWS Terraform provider supports `multi_az_enabled` flag with the default value: `false`.

This PR is meant to add the ability to change the value and enable it by default whenever the number of nodes is greater than 1 (as it doesn't have any effect if Automatic Failover is disabled).